### PR TITLE
Have Vantage client own certain events

### DIFF
--- a/examples/load_groups/monitor_load_groups.py
+++ b/examples/load_groups/monitor_load_groups.py
@@ -1,0 +1,50 @@
+"""Fetch all loads from the Vantage controller, and print out any state changes."""
+
+import argparse
+import asyncio
+import contextlib
+import logging
+from typing import Any, Dict
+
+from aiovantage import Vantage, VantageEvent
+from aiovantage.config_client.objects import LoadGroup
+
+# Grab connection info from command line arguments
+parser = argparse.ArgumentParser(description="aiovantage example")
+parser.add_argument("host", help="hostname of Vantage controller")
+parser.add_argument("--username", help="username for Vantage controller")
+parser.add_argument("--password", help="password for Vantage controller")
+parser.add_argument("--debug", help="enable debug logging", action="store_true")
+args = parser.parse_args()
+
+
+def callback(event: VantageEvent, obj: LoadGroup, data: Dict[str, Any]) -> None:
+    """Print out any state changes."""
+    if event == VantageEvent.OBJECT_ADDED:
+        print(f"[Load added] '{obj.name}' ({obj.id})")
+
+    elif event == VantageEvent.OBJECT_UPDATED:
+        print(f"[Load updated] '{obj.name}' ({obj.id})")
+        for attr in data.get("attrs_changed", []):
+            print(f"    {attr} = {getattr(obj, attr)}")
+
+
+async def main() -> None:
+    """Run code example."""
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
+
+    # Connect to the Vantage controller
+    async with Vantage(args.host, args.username, args.password) as vantage:
+        # Subscribe to updates for all load groups
+        vantage.load_groups.subscribe(callback)
+
+        # Fetch all known loads from the controller
+        await vantage.load_groups.initialize()
+
+        # Keep running for a while
+        await asyncio.sleep(3600)
+
+
+with contextlib.suppress(KeyboardInterrupt):
+    asyncio.run(main())

--- a/src/aiovantage/__init__.py
+++ b/src/aiovantage/__init__.py
@@ -4,16 +4,16 @@ __all__ = ["Vantage", "VantageEvent"]
 
 import asyncio
 from types import TracebackType
-from typing import Callable, Optional, Type
+from typing import Any, Callable, Optional, Set, Type, TypeVar
 
 from typing_extensions import Self
 
-from aiovantage.command_client import CommandClient, EventStream
+from aiovantage.command_client import CommandClient, Event, EventStream, EventType
 from aiovantage.config_client import ConfigClient
 from aiovantage.config_client.objects import SystemObject
 from aiovantage.controllers.anemo_sensors import AnemoSensorsController
 from aiovantage.controllers.areas import AreasController
-from aiovantage.controllers.base import EventCallback
+from aiovantage.controllers.base import BaseController, EventCallback
 from aiovantage.controllers.blind_groups import BlindGroupsController
 from aiovantage.controllers.blinds import BlindsController
 from aiovantage.controllers.buttons import ButtonsController
@@ -31,6 +31,8 @@ from aiovantage.controllers.tasks import TasksController
 from aiovantage.controllers.temperature_sensors import TemperatureSensorsController
 
 from .events import VantageEvent
+
+ControllerT = TypeVar("ControllerT", bound=BaseController[Any])
 
 
 class Vantage:
@@ -57,6 +59,7 @@ class Vantage:
             command_port: The port to use for the command client.
         """
         # Set up clients
+        self._host = host
         self._config_client = ConfigClient(
             host, username, password, ssl=use_ssl, port=config_port
         )
@@ -70,23 +73,30 @@ class Vantage:
         )
 
         # Set up controllers
-        self._anemo_sensors = AnemoSensorsController(self)
-        self._areas = AreasController(self)
-        self._blinds = BlindsController(self)
-        self._blind_groups = BlindGroupsController(self)
-        self._buttons = ButtonsController(self)
-        self._dry_contacts = DryContactsController(self)
-        self._gmem = GMemController(self)
-        self._light_sensors = LightSensorsController(self)
-        self._loads = LoadsController(self)
-        self._load_groups = LoadGroupsController(self)
-        self._masters = MastersController(self)
-        self._modules = ModulesController(self)
-        self._rgb_loads = RGBLoadsController(self)
-        self._omni_sensors = OmniSensorsController(self)
-        self._stations = StationsController(self)
-        self._tasks = TasksController(self)
-        self._temperature_sensors = TemperatureSensorsController(self)
+        self._controllers: Set[BaseController[Any]] = set()
+
+        def _create_controller(controller_cls: Type[ControllerT]) -> ControllerT:
+            controller = controller_cls(self)
+            self._controllers.add(controller)
+            return controller
+
+        self._anemo_sensors = _create_controller(AnemoSensorsController)
+        self._areas = _create_controller(AreasController)
+        self._blind_groups = _create_controller(BlindGroupsController)
+        self._blinds = _create_controller(BlindsController)
+        self._buttons = _create_controller(ButtonsController)
+        self._dry_contacts = _create_controller(DryContactsController)
+        self._gmem = _create_controller(GMemController)
+        self._light_sensors = _create_controller(LightSensorsController)
+        self._load_groups = _create_controller(LoadGroupsController)
+        self._loads = _create_controller(LoadsController)
+        self._masters = _create_controller(MastersController)
+        self._modules = _create_controller(ModulesController)
+        self._rgb_loads = _create_controller(RGBLoadsController)
+        self._omni_sensors = _create_controller(OmniSensorsController)
+        self._stations = _create_controller(StationsController)
+        self._tasks = _create_controller(TasksController)
+        self._temperature_sensors = _create_controller(TemperatureSensorsController)
 
     async def __aenter__(self) -> Self:
         """Return context manager."""
@@ -102,6 +112,11 @@ class Vantage:
         self.close()
         if exc_val:
             raise exc_val
+
+    @property
+    def host(self) -> str:
+        """Return the hostname or IP address of the Vantage controller."""
+        return self._host
 
     @property
     def config_client(self) -> ConfigClient:
@@ -149,6 +164,11 @@ class Vantage:
         return self._dry_contacts
 
     @property
+    def gmem(self) -> GMemController:
+        """Return the GMem controller for managing global memory."""
+        return self._gmem
+
+    @property
     def light_sensors(self) -> LightSensorsController:
         """Return the LightSensors controller for managing light sensors."""
         return self._light_sensors
@@ -172,11 +192,6 @@ class Vantage:
     def modules(self) -> ModulesController:
         """Return the Modules controller for managing modules."""
         return self._modules
-
-    @property
-    def gmem(self) -> GMemController:
-        """Return the GMem controller for managing global memory."""
-        return self._gmem
 
     @property
     def omni_sensors(self) -> OmniSensorsController:
@@ -215,24 +230,16 @@ class Vantage:
         Args:
             fetch_state: Whether to also fetch the state of each object.
         """
+        # Initialize all controllers
         await asyncio.gather(
-            self._anemo_sensors.initialize(fetch_state),
-            self._areas.initialize(fetch_state),
-            self._blinds.initialize(fetch_state),
-            self._blind_groups.initialize(fetch_state),
-            self._buttons.initialize(fetch_state),
-            self._dry_contacts.initialize(fetch_state),
-            self._gmem.initialize(fetch_state),
-            self._light_sensors.initialize(fetch_state),
-            self._loads.initialize(fetch_state),
-            self._masters.initialize(fetch_state),
-            self._modules.initialize(fetch_state),
-            self._rgb_loads.initialize(fetch_state),
-            self._omni_sensors.initialize(fetch_state),
-            self._stations.initialize(fetch_state),
-            self._tasks.initialize(fetch_state),
-            self._temperature_sensors.initialize(fetch_state),
+            *[controller.initialize(fetch_state) for controller in self._controllers]
         )
+
+        # Start the event stream
+        await self.event_stream.start()
+
+        # Subscribe to reconnect events
+        self.event_stream.subscribe(self._handle_event, EventType.RECONNECTED)
 
     def subscribe(self, callback: EventCallback[SystemObject]) -> Callable[[], None]:
         """Subscribe to state changes for all objects.
@@ -244,22 +251,7 @@ class Vantage:
             A function to unsubscribe.
         """
         unsubscribes = [
-            self.anemo_sensors.subscribe(callback),
-            self.areas.subscribe(callback),
-            self.blinds.subscribe(callback),
-            self.blind_groups.subscribe(callback),
-            self.buttons.subscribe(callback),
-            self.dry_contacts.subscribe(callback),
-            self.gmem.subscribe(callback),
-            self.light_sensors.subscribe(callback),
-            self.loads.subscribe(callback),
-            self.masters.subscribe(callback),
-            self.modules.subscribe(callback),
-            self.rgb_loads.subscribe(callback),
-            self.omni_sensors.subscribe(callback),
-            self.stations.subscribe(callback),
-            self.tasks.subscribe(callback),
-            self.temperature_sensors.subscribe(callback),
+            controller.subscribe(callback) for controller in self._controllers
         ]
 
         def unsubscribe() -> None:
@@ -267,3 +259,10 @@ class Vantage:
                 unsub()
 
         return unsubscribe
+
+    async def _handle_event(self, event: Event) -> None:
+        # Handle events from the event stream.
+        if event["type"] == EventType.RECONNECTED:
+            for controller in self._controllers:
+                if controller.initialized:
+                    await controller.fetch_full_state()

--- a/src/aiovantage/connection.py
+++ b/src/aiovantage/connection.py
@@ -128,9 +128,9 @@ class BaseConnection:
         # Read the response, with optional timeout
         try:
             data = await asyncio.wait_for(self._reader.readuntil(separator), timeout)
-        except (OSError, asyncio.IncompleteReadError) as err:
-            raise ClientConnectionError from err
         except asyncio.TimeoutError as err:
             raise ClientTimeoutError from err
+        except (OSError, asyncio.IncompleteReadError) as err:
+            raise ClientConnectionError from err
 
         return data.decode()


### PR DESCRIPTION
- Have Vantage client own certain events, e.g. `RECONNECT`
- Expose `host` property on `Vantage` class
- Expose `initialized` property on controllers
- Add new example for monitoring load groups