### PR TITLE
Fix regex in get_requires_authentication to handle multiline XML resp…

### DIFF
--- a/src/aiovantage/_config_client/connection.py
+++ b/src/aiovantage/_config_client/connection.py
@@ -92,8 +92,8 @@ class ConfigConnection(BaseConnection):
         # Responses containing the SysInfo element indicate a successful request
         # and therefore no authentication is required
         if re.search(
-            r"<IIntrospection>\s*<GetSysInfo>\s*<return>\s*"
-            r"<SysInfo>.*</SysInfo>\s*"
+            r"(?s)<IIntrospection>\s*<GetSysInfo>\s*<return>\s*"
+            r"<SysInfo>.*?</SysInfo>\s*"
             r"</return>\s*</GetSysInfo>\s*</IIntrospection>",
             response,
         ):


### PR DESCRIPTION
Fix regex pattern to handle multiline XML responses in get_requires_authentication

Currently, the regex pattern in get_requires_authentication fails to match valid SysInfo responses when they contain newlines. This causes the function to incorrectly require authentication even when the response indicates it's not needed.

Bug:
The current regex pattern uses '.*' which doesn't match newlines by default, causing it to fail on typical XML responses that contain line breaks and indentation.

Fix:
Added the (?s) flag (equivalent to re.DOTALL) to make the dot match newlines, and changed to non-greedy matching (.*?) to properly handle the XML structure.

Example XML that now works correctly:
```
<IIntrospection>
    <GetSysInfo>
        <return>
            <SysInfo>
                <MasterNumber>1</MasterNumber>
                <SerialNumber>0000000</SerialNumber>
                ...
            </SysInfo>
        </return>
    </GetSysInfo>
</IIntrospection>
```