### PR TITLE
Fix legacy firmware (2.x) response format in invoke()

### DIFF
--- a/src/aiovantage/_object_interfaces/base.py
+++ b/src/aiovantage/_object_interfaces/base.py
@@ -183,10 +183,11 @@ class Interface(metaclass=_InterfaceMeta):
 
         # Break the response into tokens
         return_line = response[-1]
-        _command, _vid, result, _method, *args = Converter.tokenize(return_line)
+        _command, _vid, result, *args = Converter.tokenize(return_line)
 
-        # Parse the response
-        return self._parse_object_response(method, result, *args, as_type=as_type)
+        # Skip the echoed method name if present; legacy firmware (2.x)
+        # omits it, while modern firmware includes it as the first arg.
+        return self._parse_object_response(method, result, *args[1:], as_type=as_type)
 
     def update_properties(self, properties: dict[str, Any]) -> list[str]:
         """Update object properties.


### PR DESCRIPTION
## Problem

Legacy Vantage InFusion firmware (2.x) omits the method name from `invoke()` responses:

```
Modern:  R:INVOKE <vid> <result> Load.GetLevel [args...]
Legacy:  R:GETLOAD <vid> <result>
```

The current code requires the method name via tuple unpacking, causing a `ValueError` that crashes controller initialization.

## Fix

Treat the echoed method name as optional instead of required. The method name was already unused (discarded as `_method`) since the caller already knows what method was invoked.

No behavior change for modern firmware.

Fixes #354