### PR TITLE
Fix missing error handling in OmniSensor.fetch_state()

### DIFF
--- a/src/aiovantage/_objects/omni_sensor.py
+++ b/src/aiovantage/_objects/omni_sensor.py
@@ -7,7 +7,9 @@ from types import NoneType
 
 from typing_extensions import override
 
+from aiovantage import logger
 from aiovantage.command_client import Converter
+from aiovantage.errors import CommandError, ConversionError
 from aiovantage.object_interfaces import SensorInterface
 
 from .sensor import Sensor
@@ -110,7 +112,15 @@ class OmniSensor(Sensor, SensorInterface):
 
     @override
     async def fetch_state(self) -> list[str]:
-        return self.update_properties({"level": await self.get_level(hw=True)})
+        # This override bypasses Interface.fetch_state(), which catches
+        # errors per property. Apply the same error handling here.
+        try:
+            level = await self.get_level(hw=True)
+        except (CommandError, ConversionError) as ex:
+            logger.warning("Failed to fetch OmniSensor level: %s", ex)
+            return []
+
+        return self.update_properties({"level": level})
 
     @override
     def handle_object_status(self, method: str, result: str, *args: str) -> list[str]:


### PR DESCRIPTION
Fixes #356

## Summary

`OmniSensor.fetch_state()` overrides `Interface.fetch_state()` to use its own `get_level()` method with custom formula-based conversion. This is intentional — the existing comment explains that OmniSensors should not use `SensorInterface` to handle state because they do additional conversion behind the scenes.

However, the override bypasses the error handling that `Interface.fetch_state()` provides. The base class wraps each property getter in a try/except for `CommandError` and `ConversionError`, logging a warning and continuing. The `OmniSensor` override calls `get_level()` directly without this protection, so any error (e.g., `NotInitializedError` from a sensor that isn't ready) propagates up unhandled and can prevent the integration from loading.

## Changes

- Add try/except around `get_level()` catching `CommandError` and `ConversionError`, matching the base class pattern
- Log a warning for visibility, consistent with `Interface.fetch_state()`
- Return `[]` (no properties changed) on error instead of raising

## Test plan

- [x] Verified integration loads cleanly with OmniSensors that report "Not Initialized"
- [x] Verified working sensors still report level correctly