### PR TITLE
Detect dead connections via a read timeout and reconnect

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
 
     steps:
       - uses: actions/checkout@v6

--- a/examples/loads/control_load.py
+++ b/examples/loads/control_load.py
@@ -6,7 +6,7 @@ import logging
 import sys
 import termios
 import tty
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager, suppress
 
 from aiovantage import Vantage
@@ -36,7 +36,7 @@ async def parse_keypress() -> str | None:
 
 
 @contextmanager
-def cbreak_mode(descriptor: int) -> Iterator[None]:
+def cbreak_mode(descriptor: int) -> Generator[None]:
     """Context manager to read terminal input character by character."""
     old_attrs = termios.tcgetattr(descriptor)
     try:

--- a/examples/loads/control_load.py
+++ b/examples/loads/control_load.py
@@ -36,7 +36,7 @@ async def parse_keypress() -> str | None:
 
 
 @contextmanager
-def cbreak_mode(descriptor: int) -> Generator[None]:
+def cbreak_mode(descriptor: int) -> Generator[None, None, None]:
     """Context manager to read terminal input character by character."""
     old_attrs = termios.tcgetattr(descriptor)
     try:

--- a/src/aiovantage/_command_client/client.py
+++ b/src/aiovantage/_command_client/client.py
@@ -9,7 +9,11 @@ from typing import Any
 from typing_extensions import Self
 
 from aiovantage._logger import logger
-from aiovantage.errors import CommandError, raise_command_error
+from aiovantage.errors import (
+    ClientConnectionError,
+    CommandError,
+    raise_command_error,
+)
 
 from .connection import CommandConnection
 from .converter import Converter
@@ -139,34 +143,42 @@ class CommandClient:
 
         # Send the command
         async with self._command_lock:
-            logger.debug("Sending command: %s", request)
-            await conn.write(f"{request}\n")
+            try:
+                logger.debug("Sending command: %s", request)
+                await conn.write(f"{request}\n")
 
-            # Read all lines of the response
-            response_lines: list[str] = []
-            while True:
-                response_line = await conn.readuntil(b"\r\n", self._read_timeout)
-                response_line = response_line.rstrip()
+                # Read all lines of the response
+                response_lines: list[str] = []
+                while True:
+                    response_line = await conn.readuntil(b"\r\n", self._read_timeout)
+                    response_line = response_line.rstrip()
 
-                # Handle command errors
-                if response_line.startswith("R:ERROR"):
-                    # Parse a command error from a message.
-                    match = re.match(r"R:ERROR:(\d+) (.+)", response_line)
-                    if not match:
-                        raise CommandError(response_line)
+                    # Handle command errors
+                    if response_line.startswith("R:ERROR"):
+                        # Parse a command error from a message.
+                        match = re.match(r"R:ERROR:(\d+) (.+)", response_line)
+                        if not match:
+                            raise CommandError(response_line)
 
-                    # Convert the error code to a specific exception, if possible
-                    raise_command_error(int(match.group(1)), match.group(2))
+                        # Convert the error code to a specific exception, if possible
+                        raise_command_error(int(match.group(1)), match.group(2))
 
-                # Ignore potentially interleaved "event" messages
-                if response_line.startswith(("S:", "L:", "EL:")):
-                    logger.debug("Ignoring event message: %s", response_line)
-                    continue
+                    # Ignore potentially interleaved "event" messages
+                    if response_line.startswith(("S:", "L:", "EL:")):
+                        logger.debug("Ignoring event message: %s", response_line)
+                        continue
 
-                # Return the response once we see the response line
-                response_lines.append(response_line)
-                if response_line.startswith("R:"):
-                    break
+                    # Return the response once we see the response line
+                    response_lines.append(response_line)
+                    if response_line.startswith("R:"):
+                        break
+            except ClientConnectionError:
+                # A read timeout or connection error leaves the socket in an unknown
+                # state; close it so the next request reconnects with a fresh socket
+                # instead of reusing a dead one (which would keep timing out until the
+                # OS finally gives up on the TCP connection, ~15 min later).
+                self._connection.close()
+                raise
 
         logger.debug("Received response: %s", "\n".join(response_lines))
 

--- a/src/aiovantage/_command_client/events.py
+++ b/src/aiovantage/_command_client/events.py
@@ -32,7 +32,8 @@ KEEPALIVE_INTERVAL = 60
 # keepalive produces traffic that resets this timeout, while on a dead connection no
 # data arrives and the read times out, surfacing the disconnect promptly. Without a
 # timeout, a hard power-off (no TCP RST) leaves the read blocked until the OS gives up
-# on the keepalive writes (~15 min), so Disconnected/reconnect never fire in time.
+# on the keepalive writes (~15 min), so the Disconnected event never fires and the
+# stream never reconnects in time.
 READ_TIMEOUT = 2 * KEEPALIVE_INTERVAL
 
 

--- a/src/aiovantage/_command_client/events.py
+++ b/src/aiovantage/_command_client/events.py
@@ -27,6 +27,14 @@ T = TypeVar("T")
 # The interval between keepalive messages, in seconds.
 KEEPALIVE_INTERVAL = 60
 
+# The maximum time to wait for a message before assuming the connection is dead.
+# Must be greater than KEEPALIVE_INTERVAL: on a healthy connection the periodic ECHO
+# keepalive produces traffic that resets this timeout, while on a dead connection no
+# data arrives and the read times out, surfacing the disconnect promptly. Without a
+# timeout, a hard power-off (no TCP RST) leaves the read blocked until the OS gives up
+# on the keepalive writes (~15 min), so Disconnected/reconnect never fire in time.
+READ_TIMEOUT = 2 * KEEPALIVE_INTERVAL
+
 
 class EventStream(EventDispatcher):
     """Client to subscribe to events from the Vantage Host Command (HC) service.
@@ -216,15 +224,24 @@ class EventStream(EventDispatcher):
                     self._resubscribe()
                 connect_attempts = 1
 
-                # Wait for new messages
+                # Wait for new messages. A read timeout (longer than the keepalive
+                # interval) ensures a dead connection is detected promptly: the ECHO
+                # keepalive keeps a healthy link's read fed, so a timeout means the
+                # connection is gone. ClientTimeoutError is a ClientConnectionError,
+                # so it falls through to the reconnect logic below.
                 while True:
-                    message = await conn.readuntil(b"\r\n")
+                    message = await conn.readuntil(b"\r\n", READ_TIMEOUT)
                     message = message.rstrip()
                     logger.debug("Received message: %s", message)
                     self._parse_message(message)
 
             except ClientConnectionError:
-                pass  # Pass through to retry logic below
+                # The connection was lost, or a read timed out (ClientTimeoutError is a
+                # ClientConnectionError) indicating a dead link. A timeout does not close
+                # the socket, so close it explicitly here - otherwise _get_connection would
+                # reuse the stale connection on the next iteration, re-emitting Reconnected
+                # on a dead socket and flapping every READ_TIMEOUT instead of recovering.
+                self._connection.close()
 
             # If we get here, the connection was lost
             if connect_attempts == 1:


### PR DESCRIPTION
## Why

The Host Command connections (event stream and command client) read with no timeout and rely on the peer closing the socket to surface a lost connection. On a hard power-off there is no TCP RST, and the event stream's `ECHO` keepalive writes only fail once the OS abandons the connection (about 15 minutes). Until then:

- the event stream read blocks forever, so `Connected` / `Disconnected` / `Reconnected` never fire and consumers keep treating the controller as online;
- the command client reads time out (it already passes `read_timeout`) but the timeout does not close the socket, and `_get_connection` only reconnects when the connection is closed, so every later request reuses the dead socket and keeps timing out.

Net effect: a powered-off or crashed controller is not detected for about 15 minutes, and per-object data does not recover until then.

## How it is implemented

- Event stream (`_command_client/events.py`): read with a timeout of `2 * KEEPALIVE_INTERVAL`. The `ECHO` keepalive round-trips every 60s on a healthy link, so 120s of silence means the link is dead. `ClientTimeoutError` subclasses `ClientConnectionError`, so it already routes into the existing reconnect path.
- Both clients: on `ClientConnectionError`, close the connection so the next `_get_connection` opens a fresh socket instead of reusing the stale one. Without this, a read timeout leaves the socket open and the event stream re-emits `Reconnected` on a dead socket, flapping every timeout and never recovering.

Two small follow-on commits keep CI green: a `Generator` (not `Iterator`) return type on a `@contextmanager` example to clear the only pyright `reportDeprecated` error, and Python 3.14 added to the lint matrix.

## How it was tested

Validated against a real InFusion controller by correlating Home Assistant entity state with ground-truth ICMP reachability across several power-off / power-on cycles:

- Connection loss detected about 108-120s after the link drops (previously not detected within 8+ minutes).
- Connection state no longer flaps while the controller is unreachable (single latched transition).
- Event stream and per-object command data both recover within a few seconds of the controller returning (previously stuck until the ~15 min OS timeout).
- Confirmed `ECHO` round-trips every 60s (`ECHO` -> `R:ECHO`), so a healthy but quiet link never reaches the read timeout.

`ruff check`, `ruff format --check`, and pyright 1.1.410 pass across the 3.10 - 3.14 matrix.
